### PR TITLE
v0.5 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,12 +60,13 @@ Most modern terminals support the Unicode symbols used in listme. For the best e
 - **path**: path to folder or file to be searched. Search is recursive.
 - **--tags (-T)**: Define the tags to search for, separated by spaces. Default tags include BUG, FIXME, XXX, TODO, HACK, OPTIMIZE, and NOTE.
 - **--glob (-g)**: Use a single-quoted glob pattern to filter files during the search (e.g., *.go).
-- **--age-limit (-l)**: Set the age limit for commits in days. Older commits are marked.
+- **--age-limit (-l)**: Set the age limit for commits in days. Older commits are marked. Default: 60 days
+- **--max-file-size (-f)**: Maximum file size to scan (in MB). Default: 5MB
 - **--full-path (-F)**: Print the full absolute path of files.
 - **--no-author (-A)**: Exclude Git author information.
 - **--no-summary (-S)**: Skip the summary box for each file.
 - **--workers (-w)**: Specify the number of search workers (usually not necessary to change).
-- **--verbose (-v)**: Enable warning verbosity.
+- **--verbose (-v)**: Enable info logging level.
 - **--debug (-d)**: Enable debug verbosity.
 
 ### Style options

--- a/blame/blame.go
+++ b/blame/blame.go
@@ -37,7 +37,7 @@ func (b *GitBlame) BlameLine(line int) (*LineBlame, error) {
 	line = line - 1
 	if line < 0 || line >= len(b.blames) {
 		err := fmt.Errorf("line out of range")
-		log.Debug(err)
+		log.Info(err)
 		return nil, err
 	}
 	return b.blames[line], nil

--- a/blame/blame.go
+++ b/blame/blame.go
@@ -131,7 +131,7 @@ func BlameFile(path string) (*GitBlame, error) {
 
 	blames := parseGitBlame(stdout)
 	if err := cmd.Wait(); err != nil {
-		err = fmt.Errorf("git blame failed: %v\n%s", err, stderr.String())
+		err = fmt.Errorf("git blame failed: %v - %s", err, stderr.String())
 		log.Debug(err)
 		return nil, err
 	}

--- a/main.go
+++ b/main.go
@@ -31,7 +31,7 @@ func main() {
 	parser := argparse.NewParser("listme", "Summarize you FIXME, TODO, XXX (and other tags) comments so you don't forget them.")
 	path := parser.StringPositional(&argparse.Options{Help: "Path to folder or file to be searched. Search is recursive."})
 	tags := parser.StringList("T", "tags", &argparse.Options{Default: tags, Validate: validateTags, Help: "Tags to search for, input should be separated by spaces"})
-	glob := parser.String("g", "glob", &argparse.Options{Default: "*.*", Help: "Glob pattern to filter files in the search. Use a single-quoted string. Example: '*.go'"})
+	glob := parser.String("g", "glob", &argparse.Options{Default: "*", Help: "Glob pattern to filter files in the search. Use a single-quoted string. Example: '*.go'"})
 	ageLimit := parser.Int("l", "age-limit", &argparse.Options{Default: 60, Help: "Age limit for commits in days. Commits older than this limit are marked"})
 	fullPath := parser.Flag("F", "full-path", &argparse.Options{Help: "Print full absolute path of the files"})
 	noAuthor := parser.Flag("A", "no-author", &argparse.Options{Help: "Do not print git author information"})

--- a/main.go
+++ b/main.go
@@ -40,7 +40,7 @@ func main() {
 	bw := parser.Flag("b", "bw", &argparse.Options{Help: "Use black and white style"})
 	plain := parser.Flag("p", "plain", &argparse.Options{Help: "Use plain style. Ideal for machine consumption. Used by default when redirecting the output"})
 	workers := parser.Int("w", "workers", &argparse.Options{Default: 128, Help: "[debug] Number of search workers. There's likely no need to change this"})
-	warning := parser.Flag("v", "verbose", &argparse.Options{Help: "Add warning verbosity"})
+	verbose := parser.Flag("v", "verbose", &argparse.Options{Help: "Enable info logging level"})
 	debug := parser.Flag("d", "debug", &argparse.Options{Help: "Add debug verbosity"})
 
 	err := parser.Parse(os.Args)
@@ -54,12 +54,12 @@ func main() {
 	}
 
 	logging.SetFormatter(format)
-	b := logging.NewLogBackend(os.Stdout, "", 0)
+	b := logging.NewLogBackend(os.Stderr, "", 0)
 	bFormatter := logging.NewBackendFormatter(b, format)
 	logging.SetBackend(bFormatter)
-	logging.SetLevel(logging.ERROR, "")
-	if *warning {
-		logging.SetLevel(logging.WARNING, "")
+	logging.SetLevel(logging.WARNING, "")
+	if *verbose {
+		logging.SetLevel(logging.INFO, "")
 	}
 	if *debug {
 		logging.SetLevel(logging.DEBUG, "")

--- a/main.go
+++ b/main.go
@@ -33,6 +33,7 @@ func main() {
 	tags := parser.StringList("T", "tags", &argparse.Options{Default: tags, Validate: validateTags, Help: "Tags to search for, input should be separated by spaces"})
 	glob := parser.String("g", "glob", &argparse.Options{Default: "*", Help: "Glob pattern to filter files in the search. Use a single-quoted string. Example: '*.go'"})
 	ageLimit := parser.Int("l", "age-limit", &argparse.Options{Default: 60, Help: "Age limit for commits in days. Commits older than this limit are marked"})
+	maxFileSize := parser.Int("f", "max-file-size", &argparse.Options{Default: 5, Help: "Maximum file size to scan (in MB)"})
 	fullPath := parser.Flag("F", "full-path", &argparse.Options{Help: "Print full absolute path of the files"})
 	noAuthor := parser.Flag("A", "no-author", &argparse.Options{Help: "Do not print git author information"})
 	noSummary := parser.Flag("S", "no-summary", &argparse.Options{Help: "Do not print summary box for each file"})
@@ -45,6 +46,11 @@ func main() {
 	err := parser.Parse(os.Args)
 	if err != nil {
 		fmt.Print(parser.Usage(err))
+		panic(err)
+	}
+
+	if *maxFileSize <= 0 {
+		panic("max-file-size must be a positive integer")
 	}
 
 	logging.SetFormatter(format)
@@ -65,7 +71,8 @@ func main() {
 	}
 
 	params, err := search.NewSearchParams(
-		*path, *tags, *workers, style, *ageLimit, *fullPath, *noSummary, *noAuthor, *glob,
+		*path, *tags, *workers, style, *ageLimit, *fullPath,
+		int64(*maxFileSize), *noSummary, *noAuthor, *glob,
 	)
 	if err != nil {
 		log.Fatal(err)

--- a/matcher/matcher.go
+++ b/matcher/matcher.go
@@ -34,7 +34,7 @@ type matcher struct {
 // parent directory, all .gitignore files are respected. The provided glob provides an additional
 // filter.
 //
-// If a glob pattern is not needed, pass "*.*".
+// If a glob pattern is not needed, pass '*'.
 func NewMatcher(path string, glob string) Matcher {
 	path = filepath.Clean(path)
 	repoRoot, err := detectDotGit(path)

--- a/matcher/matcher.go
+++ b/matcher/matcher.go
@@ -56,7 +56,7 @@ func walkGitignore(repoRoot string, refPath string) (map[string]*gitignore.GitIg
 	parseGitignore := func(path string) {
 		matcher, err := gitignore.CompileIgnoreFile(path)
 		if err != nil {
-			log.Errorf("failed to parse .gitignore %s: %v\n", path, err)
+			log.Warningf("failed to parse .gitignore %s: %v\n", path, err)
 			return
 		}
 
@@ -66,7 +66,7 @@ func walkGitignore(repoRoot string, refPath string) (map[string]*gitignore.GitIg
 
 	walker := func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
-			log.Errorf("error accessing %s: %v\n", path, err)
+			log.Errorf("file walk error: %s", err)
 			return nil
 		}
 
@@ -123,6 +123,7 @@ func (m *matcher) Match(path string) bool {
 	base := filepath.Base(path)
 	matched, err := filepath.Match(m.glob, base)
 	if err != nil {
+		log.Infof("glob match error with path %s: %s", path, err)
 		return true
 	}
 	if matched {

--- a/matcher/matcher.go
+++ b/matcher/matcher.go
@@ -166,7 +166,7 @@ func gitignoreMatch(matchers map[string]*gitignore.GitIgnore, path string, root 
 
 // MatchGit returns true if the path is a .git folder or is inside a .git folder.
 func MatchGit(path string) bool {
-	return strings.Contains(path, separator+gitDirName+separator)
+	return strings.HasSuffix(path, separator+gitDirName) || strings.Contains(path, separator+gitDirName+separator)
 }
 
 func detectDotGit(startDir string) (string, error) {

--- a/pretty/pretty.go
+++ b/pretty/pretty.go
@@ -93,8 +93,9 @@ func Emojify(tag string) string {
 		return "✐ NOTE"
 	case "HACK":
 		return "✄ HACK"
+	default:
+		return "⚠ " + tag
 	}
-	return "⚠ " + tag
 }
 
 // Colorize colorizes the provided text according to the tag and style.
@@ -118,8 +119,9 @@ func Colorize(text string, tag string, style Style) string {
 		return noteStyle.Render(text)
 	case "HACK":
 		return hackStyle.Render(text)
+	default:
+		return text
 	}
-	return text
 }
 
 // PrettyBlame returns a string with the format

--- a/search/search.go
+++ b/search/search.go
@@ -268,14 +268,14 @@ func Search(params *searchParams) {
 		}
 
 		if matcher.MatchGit(path) {
-			log.Debugf("skipping .git directory: %s", path)
+			log.Infof("skipping .git directory: %s", path)
 			return filepath.SkipDir
 		}
 
 		isDir := d.IsDir()
 		match := !params.matcher.Match(path)
 		if match {
-			log.Warningf("skipping %s due to .gitignore or glob pattern\n", path)
+			log.Infof("skipping %s due to .gitignore or glob pattern\n", path)
 			if isDir {
 				return filepath.SkipDir
 			}
@@ -288,11 +288,11 @@ func Search(params *searchParams) {
 
 		info, err := d.Info()
 		if err != nil {
-			log.Error(err)
+			log.Errorf("error getting file info for %s: %s", path, err)
 			return nil
 		}
 		if info.Size() > params.maxFs<<20 {
-			log.Errorf("skipping file larger than %dMB: %s", params.maxFs, path)
+			log.Warningf("skipping file larger than %dMB: %s", params.maxFs, path)
 			return nil
 		}
 		wg.Add(1)
@@ -325,7 +325,7 @@ func searchWorker(
 			text := scanner.Bytes()
 
 			if mimeType := http.DetectContentType(text); !strings.HasPrefix(strings.Split(mimeType, ";")[0], "text") {
-				log.Warningf("skipping non-text file of type %s: %s\n", mimeType, job.path)
+				log.Infof("skipping non-text file of type %s: %s\n", mimeType, job.path)
 				break
 			}
 
@@ -378,7 +378,7 @@ func getWidth() int {
 	s, err := tsize.GetSize()
 
 	if err != nil {
-		log.Errorf("couldn't read terminal size, using width %d: %s", defaultWidth, err)
+		log.Warningf("couldn't read terminal size, using width %d: %s", defaultWidth, err)
 		return defaultWidth
 	}
 


### PR DESCRIPTION
- closes #5 
- skip folders ignored by .gitignore rather than checking each file
- fix default glob pattern to scan files without extesion
- change core regex to detect tags without comments
- add `[no comment]` text when there's no comment (except in plain mode)
- max-file-size option to prevent hanging on very big files
- change default logging level to WARNING
- change the logging level of some messages
- change log output to Stderr