### PR TITLE
v0.6 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,20 +45,22 @@ You'll see an output like this:
 
 ![Example output screenshot](https://github.com/mathpn/listme/raw/main/screenshots/example_output.png?raw=true)
 
-`listme` respects your project's `.gitignore` files to exclude specific directories and files. If you need additional filtering, use the `--glob (-g)` option.
+`listme` respects your project's `.gitignore` files to exclude specific directories and files. If you need additional filtering, use the `--glob (-g)` option. You can also filter lines by commit author (`-a`) or by commit age in days (`-n`).
 
-Comments from commits older than a certain age (set with `--age-limit`) are tagged as old, indicating their age along with the author's name, e.g., `[OLD John Doe]`.
+Comments from commits older than a certain age (set with `--old-commit-mark-limit`) are tagged as old, indicating their age along with the author's name, e.g., `[OLD John Doe]`.
 
 ### Font and terminal support
 
-Most modern terminals support the Unicode symbols used in listme. For the best experience, we recommend using a patched font (e.g., one from **[nerd fonts](https://www.nerdfonts.com/)**).
+Most modern terminals support the Unicode symbols used in `listme`. For the best experience, we recommend using a patched font (e.g., one from **[nerd fonts](https://www.nerdfonts.com/)**).
 
-### Options
+### Arguments
 
 - **path**: Path to folder or file to be searched. Search is recursive.
 - **--tags (-T)**: Define the tags to search for, separated by spaces. Default tags include BUG, FIXME, XXX, TODO, HACK, OPTIMIZE, and NOTE.
-- **--glob (-g)**: Use a single-quoted glob pattern to filter files during the search (e.g., *.go).
-- **--age-limit (-l)**: Set the age limit for commits in days. Older commits are marked. Default: 60 days
+- **--glob (-g)**: Use a single-quoted glob pattern to filter files during the search (e.g., *.go)
+- **--author (-a)**: Filter lines by commit author
+- **--newer-than (-n)**: Filters lines based on the age of commits, showing only lines committed within the specified number of days
+- **--old-commit-mark-limit (-o)**: Sets the age limit for marking commits as old, with commits older than the specified limit being marked
 - **--max-file-size (-f)**: Maximum file size to scan (in MB). Default: 5 MB
 - **--full-path (-F)**: Print the full absolute path of files.
 - **--no-author (-A)**: Exclude Git author information.
@@ -71,7 +73,7 @@ Most modern terminals support the Unicode symbols used in listme. For the best e
 
 Choose your preferred style for output: colored (default), black-and-white (`-b`), or plain (`-p`). We recommend using the default style for the best experience.
 
-The plain style is designed for machine consumption, using a format like `file:tag:text`. If you redirect listme's output, it will automatically switch to plain style.
+The plain style is designed for machine consumption, using a format like `file:tag:text`. If you redirect `listme`'s output, it will automatically switch to plain style.
 
 ## Contributing
 

--- a/main.go
+++ b/main.go
@@ -32,6 +32,8 @@ func main() {
 	path := parser.StringPositional(&argparse.Options{Help: "Path to folder or file to be searched. Search is recursive."})
 	tags := parser.StringList("T", "tags", &argparse.Options{Default: tags, Validate: validateTags, Help: "Tags to search for, input should be separated by spaces"})
 	glob := parser.String("g", "glob", &argparse.Options{Default: "*", Help: "Glob pattern to filter files in the search. Use a single-quoted string. Example: '*.go'"})
+	author := parser.String("a", "author", &argparse.Options{Help: "Filter lines by commit author"})
+	ageFilter := parser.Int("n", "newer-than", &argparse.Options{Default: -1, Help: "Filters lines based on the age of commits, showing only lines committed within the specified number of days"})
 	oldCommitLimit := parser.Int("o", "old-commit-mark-limit", &argparse.Options{Default: 60, Help: "Sets the age limit for marking commits as old, with commits older than the specified limit being marked"})
 	maxFileSize := parser.Int("f", "max-file-size", &argparse.Options{Default: 5, Help: "Maximum file size to scan (in MB)"})
 	fullPath := parser.Flag("F", "full-path", &argparse.Options{Help: "Print full absolute path of the files"})
@@ -42,8 +44,6 @@ func main() {
 	workers := parser.Int("w", "workers", &argparse.Options{Default: 128, Help: "[debug] Number of search workers. There's likely no need to change this"})
 	verbose := parser.Flag("v", "verbose", &argparse.Options{Help: "Enable info logging level"})
 	debug := parser.Flag("d", "debug", &argparse.Options{Help: "Add debug verbosity"})
-	author := parser.String("a", "author", &argparse.Options{Help: "Filter lines by commit author"})
-	ageFilter := parser.Int("n", "newer-than", &argparse.Options{Default: -1, Help: "Filters lines based on the age of commits, showing only lines committed within the specified number of days"})
 
 	err := parser.Parse(os.Args)
 	if err != nil {

--- a/search/search.go
+++ b/search/search.go
@@ -369,7 +369,8 @@ func scanFile(
 	var triedBlame bool
 	var lineBlame *blame.LineBlame
 
-	requiresBlame := params.author != "" || (params.showAuthor && params.style != pretty.PlainStyle)
+	showAuthor := params.showAuthor && params.style != pretty.PlainStyle
+	requiresBlame := params.author != "" || !params.oldCommitTime.Equal(zeroTime) || showAuthor
 
 	for lineNumber := 1; scanner.Scan(); lineNumber++ {
 		text := scanner.Bytes()


### PR DESCRIPTION
Adds two new arguments:

- `newer-than` (-n): filters lines based on the age of commits, showing only lines committed within the specified number of days.
- `author` (-a): filter lines by commit author

Renames one argument:

- `age-limit` (-l) is renamed to `old-commit-mark-limit` (-o) to avoid confusion with the new `newer-than` parameter